### PR TITLE
Added import, minus and complement, sformat and fixed a bug

### DIFF
--- a/src/Hassium/Functions/StringFunctions.cs
+++ b/src/Hassium/Functions/StringFunctions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Hassium
 {
@@ -16,6 +17,7 @@ namespace Hassium
             result.Add("toupper", new InternalFunction(StringFunctions.ToUpper));
             result.Add("tolower", new InternalFunction(StringFunctions.ToLower));
             result.Add("contains", new InternalFunction(StringFunctions.Contains));
+            result.Add("sformat", new InternalFunction(StringFunctions.SFormat));
 
             return result;
         }
@@ -57,6 +59,11 @@ namespace Hassium
         public static object Contains(object[] args)
         {
             return args[0].ToString().Contains(args[1].ToString());
+        }
+
+        public static object SFormat(object[] args)
+        {
+            return string.Format(args[0].ToString(), args.Skip(1).ToArray());
         }
 
         private static string arrayToString(object[] args, int startIndex = 0)

--- a/src/Hassium/Interpreter/Interpreter.cs
+++ b/src/Hassium/Interpreter/Interpreter.cs
@@ -98,6 +98,8 @@ namespace Hassium
             {
                 case UnaryOperation.Not:
                     return !(bool)((evaluateNode(node.Value)));
+                case UnaryOperation.Negate:
+                    return -(double)((evaluateNode(node.Value)));
             }
             //Raise error
             return -1;

--- a/src/Hassium/Interpreter/Interpreter.cs
+++ b/src/Hassium/Interpreter/Interpreter.cs
@@ -100,6 +100,8 @@ namespace Hassium
                     return !(bool)((evaluateNode(node.Value)));
                 case UnaryOperation.Negate:
                     return -(double)((evaluateNode(node.Value)));
+                case UnaryOperation.Complement:
+                    return ~(int)(double)((evaluateNode(node.Value)));
             }
             //Raise error
             return -1;

--- a/src/Hassium/Interpreter/Interpreter.cs
+++ b/src/Hassium/Interpreter/Interpreter.cs
@@ -199,7 +199,15 @@ namespace Hassium
                 object[] arguments = new object[call.Arguments.Children.Count];
                 for (int x = 0; x < call.Arguments.Children.Count; x++)
                     arguments[x] = evaluateNode(call.Arguments.Children[x]);
-                return target.Invoke(arguments);
+                if (call.Target.ToString() == "import")
+                {
+                    var fullname = string.Join("", arguments);
+                    if (File.Exists(fullname))
+                        foreach (Dictionary<string, InternalFunction> entries in GetFunctions(fullname))
+                            foreach (KeyValuePair<string, InternalFunction> entry in entries)
+                                variables.Add(entry.Key, entry.Value);
+                }
+                else return target.Invoke(arguments);
             }
             else if (node is IdentifierNode)
             {

--- a/src/Hassium/Interpreter/Interpreter.cs
+++ b/src/Hassium/Interpreter/Interpreter.cs
@@ -202,7 +202,11 @@ namespace Hassium
                     throw new Exception("Attempt to run a non-valid function!");
                 object[] arguments = new object[call.Arguments.Children.Count];
                 for (int x = 0; x < call.Arguments.Children.Count; x++)
+                {
                     arguments[x] = evaluateNode(call.Arguments.Children[x]);
+                    if (arguments[x] is double && (((double) (arguments[x])) % 1 == 0))
+                        arguments[x] = (int) (double) arguments[x];
+                }
                 if (call.Target.ToString() == "import")
                 {
                     var fullname = string.Join("", arguments);

--- a/src/Hassium/Lexer/Lexer.cs
+++ b/src/Hassium/Lexer/Lexer.cs
@@ -42,6 +42,8 @@ namespace Hassium
                     result.Add(new Token(TokenType.Bracket, ((char) readChar()).ToString()));
                 else if ((char) (peekChar()) == ',')
                     result.Add(new Token(TokenType.Comma, ((char) readChar()).ToString()));
+                else if ((char)(peekChar()) == '~')
+                    result.Add(new Token(TokenType.Complement, ((char)readChar()).ToString()));
                 else if ("+-/*".Contains((((char) peekChar()).ToString())))
                     result.Add(new Token(TokenType.Operation, ((char) readChar()).ToString()));
                 else if ("=<>".Contains((((char) peekChar()).ToString())))

--- a/src/Hassium/Lexer/Token.cs
+++ b/src/Hassium/Lexer/Token.cs
@@ -19,7 +19,8 @@ namespace Hassium
         Not,
         Xor,
         Bitshift,
-        Modulus
+        Modulus,
+        Complement
 
     }
     public class Token

--- a/src/Hassium/Parser/Ast/ExpressionNode.cs
+++ b/src/Hassium/Parser/Ast/ExpressionNode.cs
@@ -140,6 +140,10 @@ namespace Hassium
             {
                 return new UnaryOpNode(UnaryOperation.Not, ParseUnary(parser));
             }
+            else if (parser.AcceptToken(TokenType.Operation, "-"))
+            {
+                return new UnaryOpNode(UnaryOperation.Negate, ParseUnary(parser));
+            }
             else
             {
                 return ParseFunctionCall(parser);

--- a/src/Hassium/Parser/Ast/ExpressionNode.cs
+++ b/src/Hassium/Parser/Ast/ExpressionNode.cs
@@ -144,6 +144,10 @@ namespace Hassium
             {
                 return new UnaryOpNode(UnaryOperation.Negate, ParseUnary(parser));
             }
+            else if (parser.AcceptToken(TokenType.Complement, "~"))
+            {
+                return new UnaryOpNode(UnaryOperation.Complement, ParseUnary(parser));
+            }
             else
             {
                 return ParseFunctionCall(parser);

--- a/src/Hassium/Parser/Ast/UnaryOpNode.cs
+++ b/src/Hassium/Parser/Ast/UnaryOpNode.cs
@@ -4,7 +4,8 @@ namespace Hassium
 {
     public enum UnaryOperation
     {
-        Not
+        Not,
+        Negate
     }
 
     //Class for the urinary operations

--- a/src/Hassium/Parser/Ast/UnaryOpNode.cs
+++ b/src/Hassium/Parser/Ast/UnaryOpNode.cs
@@ -5,7 +5,8 @@ namespace Hassium
     public enum UnaryOperation
     {
         Not,
-        Negate
+        Negate,
+        Complement
     }
 
     //Class for the urinary operations


### PR DESCRIPTION
- Added an "import" function to import external DLL library
- Added unary - (minus) operator
- Added ~ (complement) unary operator
- Added "sformat" (String Format) function
- Fixed a bug for functions that take Int32 instead of Double
  - For example, if you do sformat("{0:X}", 255), string.Format requires an Int32 but 255 is passed as a Double so it throws an exception. The current code converts Double to Int32 if the number is integer (only when passing args to a function).
