### PR TITLE
Lots of stuff

### DIFF
--- a/docs/Examples/Flow/TryCatchPrgm.has
+++ b/docs/Examples/Flow/TryCatchPrgm.has
@@ -5,5 +5,9 @@ try {
 } catch {
 	print("Not enough command line arguments specified!\n");
 }
+finally {
+	$ this code always executes when the try block exits, even if there's been an exception. you can then free resources, close files or connections, etc. $
+	println("That's all folks!");
+}
 
 exit(0);

--- a/docs/Introduction.md
+++ b/docs/Introduction.md
@@ -25,7 +25,7 @@ text editor (I reccomend vim for *nix) and type the code in HelloWorldPrgm.has:
 ```
 $SUMMARY: Shows a greeting to the user$
 
-print("Hello, World!");
+println("Hello, World!");
 
 exit(0);
 ```
@@ -57,7 +57,7 @@ program VariablesPrgm.has:
 $SUMMARY: Uses variables$
 
 myVar := "Hassium is free as in free beer and in freedom!";
-print(myVar, "\n");
+println(myVar);
 
 exit(0);
 ```
@@ -111,7 +111,7 @@ $SUMMARY: Reads user input and returns it back$
 
 print("Enter some text: ");
 in := input();
-print("The text you entered was: ", in, "\n");
+println("The text you entered was: ", in);;
 
 exit(0);
 ```
@@ -157,10 +157,10 @@ x := input();
 print("Enter the second number: ");
 y := input();
 
-print(x, "+", y, "=", (x + y), "\n");
-print(x, "-", y, "=", (x - y), "\n");
-print(x, "*", y, "=", (x * y), "\n");
-print(x, "/", y, "=", (x / y), "\n");
+println(x, "+", y, "=", (x + y));;
+println(x, "-", y, "=", (x - y));;
+println(x, "*", y, "=", (x * y));;
+println(x, "/", y, "=", (x / y));;
 
 exit(0);
 ```
@@ -182,14 +182,14 @@ $SUMMARY: Shows math family$
 print("Enter a number to square root: ");
 x := input();
 
-print("Square root is: ", sqrt(x), "\n");
+println("Square root is: ", sqrt(x));;
 
 print("Enter a base number: ");
 x := input();
 print("Enter a power: ");
 y := input();
 
-print("Number raised to power is: ", pow(x, y), "\n");
+println("Number raised to power is: ", pow(x, y));;
 
 exit(0);
 ```
@@ -231,7 +231,7 @@ $SUMMARY: Deletes a file we specify$
 print("Enter a file path: ");
 path := input();
 
-print("File exists: ", fexists(path), "\n");
+println("File exists: ", fexists(path));;
 dfile(path);
 
 exit(0);
@@ -359,7 +359,7 @@ if (op = "+") {
 } else if (op = "/") {
 	print(x / y);
 } else {
-	print("Unrecognized operation: ", op, "\n");
+	println("Unrecognized operation: ", op);;
 	exit(1);
 }
 
@@ -421,7 +421,7 @@ $SUMMARY: Increments and displays 1-10$
 x := 1;
 
 while(x < 11) {
-	print(x, "\n");
+	println(x);;
 	x := x + 1;
 }
 
@@ -449,7 +449,7 @@ print("Enter the end number: ");
 y := input();
 
 while (x < (y + 1)) {
-	print(x, "\n");
+	println(x);;
 	x := x + 1;
 } else {
 	print("The initial number is not less than the end number dummy!");
@@ -526,8 +526,8 @@ while(x < 5) {
 }
 
 print("The names are:\n");
-print(concatarr(first), "\n");
-print(concatarr(last), "\n");
+println(concatarr(first));;
+println(concatarr(last));;
 
 exit(0);
 ```
@@ -576,7 +576,7 @@ counts from 1 to 10 using a for loop called ForPrgm.has:
 $SUMMARY: Counts from 1 to 10 using a for loop$
 
 for (x := 1; x < 11; x := x + 1) {
-	print(x, "\n");
+	println(x);;
 }
 
 exit(0);

--- a/src/Hassium/Functions/MathFunctions.cs
+++ b/src/Hassium/Functions/MathFunctions.cs
@@ -18,12 +18,12 @@ namespace Hassium
         }
         public static object Pow(object[] args)
         {
-            return (double)(Math.Pow(Convert.ToDouble(args[0]), Convert.ToDouble(args[1])));
+            return Math.Pow(Convert.ToDouble(args[0]), Convert.ToDouble(args[1]));
         }
 
         public static object Sqrt(object[] args)
         {
-            return (double)(Math.Sqrt(Convert.ToDouble(args[0])));
+            return Math.Sqrt(Convert.ToDouble(args[0]));
         }
 
         public static object Hash(object[] args)

--- a/src/Hassium/Interpreter/Interpreter.cs
+++ b/src/Hassium/Interpreter/Interpreter.cs
@@ -272,14 +272,14 @@ namespace Hassium
             else if (node is ArrayGetNode)
             {
                 var call = (ArrayGetNode)node;
-                var arrname = call.Target.ToString();
                 Array monarr = null;
-                if (Globals.ContainsKey(arrname))
-                    if (Globals[arrname] is string)
-                        monarr = ((IEnumerable<char>) Globals[arrname]).ToArray();
-                    else monarr = (Array)Globals[arrname];
+                var evaluated = EvaluateNode(call.Target);
+                if (evaluated is string) monarr = evaluated.ToString().ToArray();
+                else if (evaluated is Array) monarr = (Array) evaluated;
                 else
-                    throw new Exception("Undefined variable: " + node);
+                {
+                    throw new Exception("The [] operator only applies to objects of type Array or String.");
+                }
                 var arguments = new object[call.Arguments.Children.Count];
                 for (var x = 0; x < call.Arguments.Children.Count; x++)
                     arguments[x] = EvaluateNode(call.Arguments.Children[x]);

--- a/src/Hassium/Interpreter/Interpreter.cs
+++ b/src/Hassium/Interpreter/Interpreter.cs
@@ -275,7 +275,9 @@ namespace Hassium
                 var arrname = call.Target.ToString();
                 Array monarr = null;
                 if (Globals.ContainsKey(arrname))
-                    monarr = (Array)Globals[arrname];
+                    if (Globals[arrname] is string)
+                        monarr = ((IEnumerable<char>) Globals[arrname]).ToArray();
+                    else monarr = (Array)Globals[arrname];
                 else
                     throw new Exception("Undefined variable: " + node);
                 var arguments = new object[call.Arguments.Children.Count];

--- a/src/Hassium/Interpreter/Interpreter.cs
+++ b/src/Hassium/Interpreter/Interpreter.cs
@@ -111,9 +111,10 @@ namespace Hassium
                 case BinaryOperation.Modulus:
                     return Convert.ToDouble(EvaluateNode(node.Left)) % Convert.ToDouble(EvaluateNode(node.Right));
 
-                    case BinaryOperation.Pow:
-                    return Math.Pow(Convert.ToDouble(EvaluateNode(node.Left)),
-                        Convert.ToDouble(EvaluateNode(node.Right)));
+                case BinaryOperation.Pow:
+                    return Math.Pow(Convert.ToDouble(EvaluateNode(node.Left)), Convert.ToDouble(EvaluateNode(node.Right)));
+                case BinaryOperation.Root:
+                    return Math.Pow(Convert.ToDouble(EvaluateNode(node.Left)), 1.0 / Convert.ToDouble(EvaluateNode(node.Right)));
             }
             // Raise error
             return -1;
@@ -124,11 +125,11 @@ namespace Hassium
             switch (node.UnOp)
             {
                 case UnaryOperation.Not:
-                    return !(bool)((EvaluateNode(node.Value)));
+                    return !Convert.ToBoolean((EvaluateNode(node.Value)));
                 case UnaryOperation.Negate:
-                    return -(double)((EvaluateNode(node.Value)));
+                    return -Convert.ToDouble((EvaluateNode(node.Value)));
                 case UnaryOperation.Complement:
-                    return ~(int)(double)((EvaluateNode(node.Value)));
+                    return ~(int)Convert.ToDouble((EvaluateNode(node.Value)));
             }
             //Raise error
             return -1;

--- a/src/Hassium/Lexer/Lexer.cs
+++ b/src/Hassium/Lexer/Lexer.cs
@@ -55,7 +55,7 @@ namespace Hassium
                 else if (current == ':' && next1 == '=')
                     Add(new Token(TokenType.Assignment, ReadChar() + "" + ReadChar()));
 
-                else if (current == '=' && next1 == '=')
+                else if (current == '=')
                     Add(new Token(TokenType.Comparison, ReadChar() + "" + ReadChar()));
                 else if (current == '!' && next1 == '=')
                     Add(new Token(TokenType.Comparison, ReadChar() + "" + ReadChar()));

--- a/src/Hassium/Lexer/Token.cs
+++ b/src/Hassium/Lexer/Token.cs
@@ -4,31 +4,28 @@ namespace Hassium
 {
     public enum TokenType
     {
-        Identifier,
         Brace,
         Bracket,
+        Identifier,
         String,
         Number,
         Parentheses,
         Comma,
         Operation,
+        OpAssign,
         Comparison,
-        Store,
+        Assignment,
         Exception,
         EndOfLine,
-        Not,
-        Xor,
-        Bitshift,
-        Modulus,
-        Complement
+        UnaryOperation
 
     }
     public class Token
     {
         public TokenType TokenClass { get; private set; }
-        public string Value { get; private set; }
+        public object Value { get; private set; }
 
-        public Token(TokenType type, string value)
+        public Token(TokenType type, object value)
         {
             this.TokenClass = type;
             this.Value = value;

--- a/src/Hassium/MyClass.cs
+++ b/src/Hassium/MyClass.cs
@@ -35,7 +35,19 @@ namespace Hassium
             Parser hassiumParser = new Parser(tokens);
             AstNode ast = hassiumParser.Parse();
 
-            new Interpreter(new SemanticAnalyser(ast).Analyse(), ast).Execute();
+            try
+            {
+                new Interpreter(new SemanticAnalyser(ast).Analyse(), ast).Execute();
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine("ERROR: " + e.Message);
+                Console.WriteLine("Press Y to show full stack trace");
+                if (Console.ReadKey(true).Key == ConsoleKey.Y)
+                {
+                    Console.WriteLine(e);
+                }
+            }
         }
 
         private static string[] shiftArray(string[] args, int startIndex = 1)

--- a/src/Hassium/MyClass.cs
+++ b/src/Hassium/MyClass.cs
@@ -83,6 +83,7 @@ namespace Hassium
 
             Interpreter.Globals.Add("true", true);
             Interpreter.Globals.Add("false", false);
+            Interpreter.Globals.Add("null", null);
 
             options.Code = File.ReadAllText(options.FilePath);
 

--- a/src/Hassium/Parser/Ast/BinaryOpNode.cs
+++ b/src/Hassium/Parser/Ast/BinaryOpNode.cs
@@ -20,12 +20,18 @@ namespace Hassium
         Xor,
         BitshiftLeft,
         BitshiftRight,
-        Modulus
+        Modulus,
+        BitwiseAnd,
+        BitwiseOr,
+        Pow,
+        Root
     }
 
     public class BinOpNode : AstNode
     {
         public BinaryOperation BinOp { get; set; }
+        public BinaryOperation AssignOperation { get; set; }
+        public bool IsAssign { get; set; }
         public AstNode Left
         {
             get 
@@ -47,6 +53,15 @@ namespace Hassium
             this.BinOp = type;
             this.Children.Add(left);
             this.Children.Add(right);
+        }
+
+        public BinOpNode(BinaryOperation type, BinaryOperation assign, AstNode left, AstNode right)
+        {
+            BinOp = type;
+            AssignOperation = assign;
+            IsAssign = true;
+            Children.Add(left);
+            Children.Add(right);
         }
     }
 }

--- a/src/Hassium/Parser/Ast/ExpressionNode.cs
+++ b/src/Hassium/Parser/Ast/ExpressionNode.cs
@@ -98,7 +98,7 @@ namespace Hassium
         private static AstNode ParseEquality (Parser parser)
         {
             AstNode left = ParseAdditive(parser);
-            if (parser.AcceptToken(TokenType.Comparison, "=="))
+            if (parser.AcceptToken(TokenType.Comparison, "="))
             {
                 var right = ParseEquality(parser);
                 return new BinOpNode(BinaryOperation.Equals, left, right);

--- a/src/Hassium/Parser/Ast/ExpressionNode.cs
+++ b/src/Hassium/Parser/Ast/ExpressionNode.cs
@@ -4,6 +4,70 @@ namespace Hassium
 {
     public static class ExpressionNode
     {
+        private static BinaryOperation GetBinaryOp(string value)
+        {
+            switch (value)
+            {
+                case "**":
+                case "**=":
+                    return BinaryOperation.Pow;
+                case "//":
+                case "//=":
+                    return BinaryOperation.Root;
+                case ">>":
+                case ">>=":
+                    return BinaryOperation.BitshiftRight;
+                case "<<":
+                case "<<=":
+                    return BinaryOperation.BitshiftLeft;
+                case "+":
+                case "+=":
+                    return BinaryOperation.Addition;
+                case "-":
+                case "-=":
+                    return BinaryOperation.Subtraction;
+                case "/":
+                case "/=":
+                    return BinaryOperation.Division;
+                case "*":
+                case "*=":
+                    return BinaryOperation.Multiplication;
+                case "%":
+                case "%=":
+                    return BinaryOperation.Modulus;
+                case "&":
+                case "&=":
+                    return BinaryOperation.BitwiseAnd;
+                case "|":
+                case "|=":
+                    return BinaryOperation.BitwiseOr;
+                case "^":
+                case "^=":
+                    return BinaryOperation.Xor;
+                case "=":
+                    return BinaryOperation.Assignment;
+                case "==":
+                    return BinaryOperation.Equals;
+                case "!=":
+                    return BinaryOperation.NotEqualTo;
+                case ">":
+                    return BinaryOperation.GreaterThan;
+                case ">=":
+                    return BinaryOperation.GreaterOrEqual;
+                case "<":
+                    return BinaryOperation.LessThan;
+                case "<=":
+                    return BinaryOperation.LesserOrEqual;
+                case "&&":
+                    return BinaryOperation.And;
+                case "||":
+                    return BinaryOperation.Or;
+                default:
+                    throw new ArgumentException("Invalid binary operation: " + value);
+            }
+        }
+
+
         public static AstNode Parse(Parser parser)
         {
             return ParseAssignment(parser);
@@ -14,10 +78,16 @@ namespace Hassium
         {
             AstNode left = ParseEquality(parser);
 
-            if (parser.AcceptToken(TokenType.Store))
+            if (parser.AcceptToken(TokenType.Assignment))
             {
                 AstNode right = ParseAssignment(parser);
                 return new BinOpNode(BinaryOperation.Assignment, left, right);
+            }
+            else if (parser.AcceptToken(TokenType.OpAssign))
+            {
+                var assigntype = GetBinaryOp(parser.PreviousToken().Value.ToString());
+                var right = ParseAssignment(parser);
+                return new BinOpNode(BinaryOperation.Assignment, assigntype, left, right);
             }
             else
             {
@@ -28,60 +98,75 @@ namespace Hassium
         private static AstNode ParseEquality (Parser parser)
         {
             AstNode left = ParseAdditive(parser);
-            if (parser.AcceptToken(TokenType.Comparison, "="))
+            if (parser.AcceptToken(TokenType.Comparison, "=="))
             {
-                AstNode right = ParseEquality(parser);
+                var right = ParseEquality(parser);
                 return new BinOpNode(BinaryOperation.Equals, left, right);
             }
             else if (parser.AcceptToken(TokenType.Comparison, "!="))
             {
-                AstNode right = ParseEquality(parser);
+                var right = ParseEquality(parser);
                 return new BinOpNode(BinaryOperation.NotEqualTo, left, right);
             }
             else if (parser.AcceptToken(TokenType.Comparison, "<"))
             {
-                AstNode right = ParseEquality(parser);
+                var right = ParseEquality(parser);
                 return new BinOpNode(BinaryOperation.LessThan, left, right);
             }
             else if (parser.AcceptToken(TokenType.Comparison, ">"))
             {
-                AstNode right = ParseEquality(parser);
+                var right = ParseEquality(parser);
                 return new BinOpNode(BinaryOperation.GreaterThan, left, right);
             }
             else if (parser.AcceptToken(TokenType.Comparison, "<="))
             {
-                AstNode right = ParseEquality(parser);
+                var right = ParseEquality(parser);
                 return new BinOpNode(BinaryOperation.LesserOrEqual, left, right);
             }
             else if (parser.AcceptToken(TokenType.Comparison, ">="))
             {
-                AstNode right = ParseEquality(parser);
+                var right = ParseEquality(parser);
                 return new BinOpNode(BinaryOperation.GreaterOrEqual, left, right);
             }
             else if (parser.AcceptToken(TokenType.Comparison, "&&"))
             {
-                AstNode right = ParseEquality(parser);
+                var right = ParseEquality(parser);
+                return new BinOpNode(BinaryOperation.And, left, right);
+            }
+            else if (parser.AcceptToken(TokenType.Comparison, "&&"))
+            {
+                var right = ParseEquality(parser);
                 return new BinOpNode(BinaryOperation.And, left, right);
             }
             else if (parser.AcceptToken(TokenType.Comparison, "||"))
             {
-                AstNode right = ParseEquality(parser);
+                var right = ParseEquality(parser);
                 return new BinOpNode(BinaryOperation.Or, left, right);
             }
-            else if (parser.AcceptToken(TokenType.Xor, "^"))
+            else if (parser.AcceptToken(TokenType.Operation, "^"))
             {
-                AstNode right = ParseEquality(parser);
+                var right = ParseEquality(parser);
                 return new BinOpNode(BinaryOperation.Xor, left, right);
             }
-            else if (parser.AcceptToken(TokenType.Bitshift, "<<"))
+            else if (parser.AcceptToken(TokenType.Operation, "<<"))
             {
-                AstNode right = ParseEquality(parser);
+                var right = ParseEquality(parser);
                 return new BinOpNode(BinaryOperation.BitshiftLeft, left, right);
             }
-            else if (parser.AcceptToken(TokenType.Bitshift, ">>"))
+            else if (parser.AcceptToken(TokenType.Operation, ">>"))
             {
-                AstNode right = ParseEquality(parser);
+                var right = ParseEquality(parser);
                 return new BinOpNode(BinaryOperation.BitshiftRight, left, right);
+            }
+            else if (parser.AcceptToken(TokenType.Operation, "&"))
+            {
+                var right = ParseEquality(parser);
+                return new BinOpNode(BinaryOperation.BitwiseAnd, left, right);
+            }
+            else if (parser.AcceptToken(TokenType.Operation, "|"))
+            {
+                var right = ParseEquality(parser);
+                return new BinOpNode(BinaryOperation.BitwiseOr, left, right);
             }
             else
             {
@@ -123,7 +208,7 @@ namespace Hassium
                 AstNode right = ParseMultiplicative(parser);
                 return new BinOpNode(BinaryOperation.Division, left, right);
             }
-            else  if (parser.AcceptToken(TokenType.Modulus, "%"))
+            else  if (parser.AcceptToken(TokenType.Operation, "%"))
             {
                 AstNode right = ParseMultiplicative(parser);
                 return new BinOpNode(BinaryOperation.Modulus, left, right);
@@ -136,7 +221,7 @@ namespace Hassium
 
         private static AstNode ParseUnary(Parser parser)
         {
-            if (parser.AcceptToken(TokenType.Not, "!"))
+            if (parser.AcceptToken(TokenType.UnaryOperation, "!"))
             {
                 return new UnaryOpNode(UnaryOperation.Not, ParseUnary(parser));
             }
@@ -144,7 +229,7 @@ namespace Hassium
             {
                 return new UnaryOpNode(UnaryOperation.Negate, ParseUnary(parser));
             }
-            else if (parser.AcceptToken(TokenType.Complement, "~"))
+            else if (parser.AcceptToken(TokenType.UnaryOperation, "~"))
             {
                 return new UnaryOpNode(UnaryOperation.Complement, ParseUnary(parser));
             }
@@ -195,11 +280,11 @@ namespace Hassium
             }
             else if (parser.MatchToken(TokenType.String))
             {
-                return new StringNode(parser.ExpectToken(TokenType.String).Value);
+                return new StringNode(parser.ExpectToken(TokenType.String).Value.ToString());
             }
             else if (parser.MatchToken(TokenType.Identifier))
             {
-                return new IdentifierNode(parser.ExpectToken(TokenType.Identifier).Value);
+                return new IdentifierNode(parser.ExpectToken(TokenType.Identifier).Value.ToString());
             }
             else
             {

--- a/src/Hassium/Parser/Ast/FuncNode.cs
+++ b/src/Hassium/Parser/Ast/FuncNode.cs
@@ -26,13 +26,13 @@ namespace Hassium
         public static AstNode Parse(Parser parser)
         {
             parser.ExpectToken(TokenType.Identifier);
-            string name = parser.ExpectToken(TokenType.Identifier).Value;
+            string name = parser.ExpectToken(TokenType.Identifier).Value.ToString();
             parser.ExpectToken(TokenType.Parentheses, "(");
 
             List<string> result = new List<string>();
             while (parser.MatchToken(TokenType.Identifier))
             {
-                result.Add(parser.ExpectToken(TokenType.Identifier).Value);
+                result.Add(parser.ExpectToken(TokenType.Identifier).Value.ToString());
                 if (!parser.AcceptToken(TokenType.Comma))
                     break;
             }

--- a/src/Hassium/Parser/Ast/TryNode.cs
+++ b/src/Hassium/Parser/Ast/TryNode.cs
@@ -20,10 +20,25 @@ namespace Hassium
             }
         }
 
+        public AstNode FinallyBody
+        {
+            get
+            {
+                return this.Children[2];
+            }
+        }
+
         public TryNode(AstNode body, AstNode catchBody)
         {
             this.Children.Add(body);
             this.Children.Add(catchBody);
+        }
+
+        public TryNode(AstNode body, AstNode catchBody, AstNode finallyBody)
+        {
+            this.Children.Add(body);
+            this.Children.Add(catchBody);
+            Children.Add(finallyBody);
         }
 
         public static AstNode Parse(Parser parser)
@@ -32,6 +47,12 @@ namespace Hassium
             AstNode tryBody = StatementNode.Parse(parser);
             parser.ExpectToken(TokenType.Identifier, "catch");
             AstNode catchBody = StatementNode.Parse(parser);
+
+            if (parser.AcceptToken(TokenType.Identifier, "finally"))
+            {
+                AstNode finallyBody = StatementNode.Parse(parser);
+                return new TryNode(tryBody, catchBody, finallyBody);
+            }
 
             return new TryNode(tryBody, catchBody);
         }

--- a/src/Hassium/Parser/Parser.cs
+++ b/src/Hassium/Parser/Parser.cs
@@ -36,6 +36,11 @@ namespace Hassium
             return tokens[position];
         }
 
+        public Token PreviousToken()
+        {
+            return tokens[position - 1];
+        }
+
         public bool MatchToken(TokenType clazz)
         {
             return position < tokens.Count && tokens[position].TokenClass == clazz;
@@ -43,7 +48,7 @@ namespace Hassium
 
         public bool MatchToken(TokenType clazz, string value)
         {
-            return position < tokens.Count && tokens[position].TokenClass == clazz && tokens[position].Value == value;
+            return position < tokens.Count && tokens[position].TokenClass == clazz && tokens[position].Value.ToString() == value.ToString();
         }
 
         public bool AcceptToken(TokenType clazz)


### PR DESCRIPTION
- Added bitwise And (&), Or (|), Pow (**) and Root (//).
- Fixed some cast problems in the interpreter
- Re-ordered the Lexer and made the code more beautiful
- Added Op-Assign operators (like x += 1, an operation and an assignment)
- Added Bit Shift left << and right >>.
- Added "finally" support for the existing try-catch block.
- Added string support for array stuff (for example, you can now do `x := "abc"; println(x[2]);` as if x was an array of characters)
- The code for ArrayGetNode in the interpreter now calls evaluateNode instead of getting variables so now it works with everything that returns a value. (for example, you can do `println("abc"[2]);`)
- Added a RuntimeCall method for calling the .NET Framework. Example: `runtimecall("System.Console.WriteLine", "test");` or `x := runtimecall("System.Math.PI");`
- Added error handling. Now, if there's an exception, instead of showing the full .NET Framework stack trace it shows : 

```
ERROR: abcabcabcabc
Press Y to show full stack trace
```
- Added null constant
